### PR TITLE
cp210x: Convert return of pyusb.ctrl_transfer to bytearray

### DIFF
--- a/cp210x/cp210x.py
+++ b/cp210x/cp210x.py
@@ -219,7 +219,7 @@ class Cp210xProgrammer(object):
     def _get_config(self, value, length, index=0, request=CP210x_CONFIG):
         res = self.usbdev.ctrl_transfer(CTRL_IN | CTRL_TYPE_VENDOR,
                                         request, value, index, length)
-        return res.tostring()
+        return res.tobytes()
 
     def _get_int8_config(self, value, index=0, request=CP210x_CONFIG):
         return ord(self._get_config(value, 1, index=index, request=request))


### PR DESCRIPTION
This solves the following error:
```
Traceback (most recent call last):
File
".../cp210x-program/./cp210x-program",
line 239, in <module>
    main()
File
".../cp210x-program/./cp210x-program",
line 235, in main
    options.action(options)
File
".../cp210x-program/./cp210x-program",
line 140, in read_cp210x
    eeprom = EEPROM(dev)
File
".../cp210x-program/cp210x/eeprom.py",
line 67, in __init__
    self.content = content.get_eeprom_content()
File
".../cp210x-program/cp210x/cp210x.py",
line 235, in get_eeprom_content
    return self._get_config(REG_EEPROM, SIZE_EEPROM)
File
".../cp210x-program/cp210x/cp210x.py",
line 223, in _get_config
    return res.tostring()
AttributeError: 'array.array' object has no attribute 'tostring'
```

In my case res contains a value like the following:
array('B', [255, ..., 255])

Tested with the following setup
- Linux kernel 5.9.0-5-amd64
- Debian bullseye
- python 3.9.1
- python3-usb 1.0.2-2
- $ ./cp210x-program