### PR TITLE
cp210x: Provide baud rate table as bytearray to pyusb

### DIFF
--- a/cp210x/cp210x.py
+++ b/cp210x/cp210x.py
@@ -109,7 +109,7 @@ def parse_baudrate_cfg(data):
 
 def build_baudrate_cfg(baudgen, timer0reload, prescaler, baudrate):
     return (to_binary(baudgen, le=False) + to_binary(timer0reload, le=False) + 
-            to_binary(prescaler, 1) + '\x00' + to_binary(baudrate, 4))
+            to_binary(prescaler, 1) + bytes([0]) + to_binary(baudrate, 4))
 
 class Cp210xError(IOError):
     pass
@@ -286,7 +286,7 @@ class Cp210xProgrammer(object):
         """
         assert len(content) == SIZE_EEPROM, ("EEPROM data must be %i bytes."
                                              % SIZE_EEPROM)
-        assert isinstance(content, str), "EEPROM data must be string."
+        assert isinstance(content, bytes), "EEPROM data must be bytes."
         self._set_config(REG_EEPROM, data=content)
     
     def set_product_id(self, pid):

--- a/cp210x/eeprom.py
+++ b/cp210x/eeprom.py
@@ -161,7 +161,7 @@ class EEPROM(object):
     def _set_baudrate_table(self, baudrates):
         assert len(baudrates) == cp210x.SIZE_BAUDRATES
         self.set(POS_BAUDRATE_TABLE, 
-                 ''.join(cp210x.build_baudrate_cfg(*cfg) for cfg in baudrates))
+                 b"".join(cp210x.build_baudrate_cfg(*cfg) for cfg in baudrates))
     baudrate_table = property(_get_baudrate_table, _set_baudrate_table)
     product_string = _str_value(POS_PRODUCT_STRING, cp210x.SIZE_PRODUCT_STRING)
     serial_number = _str_value(POS_SERIAL_NUMBER, cp210x.SIZE_SERIAL_NUMBER)


### PR DESCRIPTION
Without this modification the following error is shown:

> Traceback (most recent call last):
File
".../cp210x-program/./cp210x-program",
line 239, in <module>
    main()
File
".../cp210x-program/./cp210x-program",
line 235, in main
    options.action(options)
File
".../cp210x-program/./cp210x-program",
line 163, in write_cp210x
    eeprom.set_values(values)
File
".../cp210x-program/cp210x/eeprom.py",
line 188, in set_values
    setattr(self, name, value)
File
".../cp210x-program/cp210x/eeprom.py",
line 164, in _set_baudrate_table
    ''.join(cp210x.build_baudrate_cfg(*cfg) for cfg in baudrates))
File
".../cp210x-program/cp210x/eeprom.py",
line 164, in <genexpr>
    ''.join(cp210x.build_baudrate_cfg(*cfg) for cfg in baudrates))
File
".../cp210x-program/cp210x/cp210x.py",
line 111, in build_baudrate_cfg
return (to_binary(baudgen, le=False) + to_binary(timer0reload,
le=False) +
TypeError: can't concat str to bytes

Passing strings to pyusb is deprecated. See usb/interop.py: as_array():
> a.fromstring(data) # deprecated since 3.2

Tested with the following setup
- Linux kernel 5.9.0-5-amd64
- Debian bullseye
- python 3.9.1
- python3-usb 1.0.2-2
- $ ./cp210x-program --write-cp210x -F testdata/cp2102-orig.hex