### PR TITLE
ini: Allow inline comments

### DIFF
--- a/cp210x/valuefile.py
+++ b/cp210x/valuefile.py
@@ -80,7 +80,7 @@ TYPES = {
 }
 
 def read_file(fp):
-    cp = ConfigParser()
+    cp = ConfigParser(inline_comment_prefixes=('#', ';'))
     if isinstance(fp, str):
         cp.read([fp])
     else:


### PR DESCRIPTION
Without this modification the script can not read the testdata ini files due to the inline comments starting with `#`