### PR TITLE
Update udev rules for modern udev

### DIFF
--- a/doc/45-cp210x-programming.rules
+++ b/doc/45-cp210x-programming.rules
@@ -1,9 +1,9 @@
 # udev rules file for CP210x device to be programmable py
 # cp210x-program
 
-SUBSYSTEM!="usb_device", GOTO="cp210x-programming_rules_end"
+SUBSYSTEM!="usb", GOTO="cp210x-programming_rules_end"
 
-SYSFS{idVendor}=="10C4", SYSFS{idProduct}=="EA60", MODE="0660", GROUP="plugdev"
-SYSFS{idVendor}=="10C4", SYSFS{idProduct}=="EA61", MODE="0660", GROUP="plugdev"
+ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea60", MODE="0664", GROUP="plugdev"
+ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea61", MODE="0664", GROUP="plugdev"
 
 LABEL="cp210x-programming_rules_end"


### PR DESCRIPTION
Modern versions of udev use `ATTR` instead of `SYSFS` to match sysfs properties. In addition, the `SUBSYSTEM` is `usb`, not `usb_device`