### PR TITLE
Fix tox.ini passenv values

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,10 @@ commands =
     cp210x-program.py --version
 
 [testenv:readhex]
-passenv = CI PYTHON PYTHONIOENCODING
+passenv =
+    CI
+    PYTHON
+    PYTHONIOENCODING
 skip_install = true
 
 allowlist_externals =
@@ -115,7 +118,10 @@ commands =
     cp210x-program.py --read-cp210x -f readhex.out
 
 [testenv:read]
-passenv = CI PYTHON PYTHONIOENCODING
+passenv =
+    CI
+    PYTHON
+    PYTHONIOENCODING
 skip_install = true
 
 allowlist_externals =


### PR DESCRIPTION
When you try to read with tox 4.11.1 (tox -e read) it generates error:

> read: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'CI PYTHON PYTHONIOENCODING'

This commit splits by lines passenv values and thus avoids the error.